### PR TITLE
fix: remove duplicate script, fix nginx scripts

### DIFF
--- a/30-oss-services.sh
+++ b/30-oss-services.sh
@@ -9,5 +9,3 @@ if [ "$SWAGGER_OSS_SERVICES" ]; then
   sed -i "s|\${window.location.host}=\${defaultDefinitionUrl}|$SWAGGER_OSS_SERVICES|g" $INDEX_FILE
 fi
 
-# applies gzip to assets for faster serving; index.html.gz takes preference over index.html
-find $NGINX_ROOT -type f -regex ".*\.\(html\|js\|css\)" -exec sh -c "gzip < {} > {}.gz" \;

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM swaggerapi/swagger-ui:latest
 ENV SWAGGER_OSS_SERVICES ""
 
 COPY ./index.html /usr/share/nginx/html/index.html
-COPY ./50-oss-services.sh /docker-entrypoint.d/
+COPY ./30-oss-services.sh /docker-entrypoint.d/
 
-RUN chmod +x /docker-entrypoint.d/50-oss-services.sh
+RUN chmod +x /docker-entrypoint.d/30-oss-services.sh
 RUN chmod 777 /usr/share/nginx/html/index.html
 

--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
     <div id="swagger-ui"></div>
     <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
     <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
-    <script src="./swagger-initializer.js" charset="UTF-8"> </script>
     <script>
       window.onload = function() {
         const defaultDefinitionUrl = "https://petstore.swagger.io/v2/swagger.json";


### PR DESCRIPTION
* Executes custom image nginx script first, with no compression of content which is executed by Swagger UI script afterwards. This is an optimization to avoid duplicating compression in both original and custom image scripts
* Remove `swagger-initializer.js` script from index.html, as the logic is provided in the customized index.html, while `swagger-initializer.js` is in use by the original image